### PR TITLE
supported replace http.Client

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -11,9 +11,9 @@ type adminResponse struct {
 	Error string `json:"error"`
 }
 
-func adminRequest(method string, teamName string, values url.Values, debug bool) (*adminResponse, error) {
+func (api *Client) adminRequest(method string, teamName string, values url.Values, debug bool) (*adminResponse, error) {
 	adminResponse := &adminResponse{}
-	err := parseAdminResponse(method, teamName, values, adminResponse, debug)
+	err := api.parseAdminResponse(method, teamName, values, adminResponse, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +34,7 @@ func (api *Client) DisableUser(teamName string, uid string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setInactive", teamName, values, api.debug)
+	_, err := api.adminRequest("setInactive", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to disable user with id '%s': %s", uid, err)
 	}
@@ -61,7 +61,7 @@ func (api *Client) InviteGuest(
 		"_attempts":        {"1"},
 	}
 
-	_, err := adminRequest("invite", teamName, values, api.debug)
+	_, err := api.adminRequest("invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to invite single-channel guest: %s", err)
 	}
@@ -88,7 +88,7 @@ func (api *Client) InviteRestricted(
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("invite", teamName, values, api.debug)
+	_, err := api.adminRequest("invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to restricted account: %s", err)
 	}
@@ -112,7 +112,7 @@ func (api *Client) InviteToTeam(
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("invite", teamName, values, api.debug)
+	_, err := api.adminRequest("invite", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to invite to team: %s", err)
 	}
@@ -129,7 +129,7 @@ func (api *Client) SetRegular(teamName string, user string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setRegular", teamName, values, api.debug)
+	_, err := api.adminRequest("setRegular", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to change the user (%s) to a regular user: %s", user, err)
 	}
@@ -146,7 +146,7 @@ func (api *Client) SendSSOBindingEmail(teamName string, user string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("sendSSOBind", teamName, values, api.debug)
+	_, err := api.adminRequest("sendSSOBind", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to send SSO binding email for user (%s): %s", user, err)
 	}
@@ -164,7 +164,7 @@ func (api *Client) SetUltraRestricted(teamName, uid, channel string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setUltraRestricted", teamName, values, api.debug)
+	_, err := api.adminRequest("setUltraRestricted", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to ultra-restrict account: %s", err)
 	}
@@ -181,7 +181,7 @@ func (api *Client) SetRestricted(teamName, uid string) error {
 		"_attempts":  {"1"},
 	}
 
-	_, err := adminRequest("setRestricted", teamName, values, api.debug)
+	_, err := api.adminRequest("setRestricted", teamName, values, api.debug)
 	if err != nil {
 		return fmt.Errorf("Failed to restrict account: %s", err)
 	}

--- a/channels.go
+++ b/channels.go
@@ -24,9 +24,9 @@ type Channel struct {
 	IsMember  bool `json:"is_member"`
 }
 
-func channelRequest(path string, values url.Values, debug bool) (*channelResponseFull, error) {
+func (api *Client) channelRequest(path string, values url.Values, debug bool) (*channelResponseFull, error) {
 	response := &channelResponseFull{}
-	err := post(path, values, response, debug)
+	err := api.post(path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (api *Client) ArchiveChannel(channel string) error {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	_, err := channelRequest("channels.archive", values, api.debug)
+	_, err := api.channelRequest("channels.archive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (api *Client) UnarchiveChannel(channel string) error {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	_, err := channelRequest("channels.unarchive", values, api.debug)
+	_, err := api.channelRequest("channels.unarchive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (api *Client) CreateChannel(channel string) (*Channel, error) {
 		"token": {api.config.token},
 		"name":  {channel},
 	}
-	response, err := channelRequest("channels.create", values, api.debug)
+	response, err := api.channelRequest("channels.create", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (api *Client) GetChannelHistory(channel string, params HistoryParameters) (
 			values.Add("inclusive", "0")
 		}
 	}
-	response, err := channelRequest("channels.history", values, api.debug)
+	response, err := api.channelRequest("channels.history", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (api *Client) GetChannelInfo(channel string) (*Channel, error) {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	response, err := channelRequest("channels.info", values, api.debug)
+	response, err := api.channelRequest("channels.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (api *Client) InviteUserToChannel(channel, user string) (*Channel, error) {
 		"channel": {channel},
 		"user":    {user},
 	}
-	response, err := channelRequest("channels.invite", values, api.debug)
+	response, err := api.channelRequest("channels.invite", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (api *Client) JoinChannel(channel string) (*Channel, error) {
 		"token": {api.config.token},
 		"name":  {channel},
 	}
-	response, err := channelRequest("channels.join", values, api.debug)
+	response, err := api.channelRequest("channels.join", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (api *Client) LeaveChannel(channel string) (bool, error) {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	response, err := channelRequest("channels.leave", values, api.debug)
+	response, err := api.channelRequest("channels.leave", values, api.debug)
 	if err != nil {
 		return false, err
 	}
@@ -167,7 +167,7 @@ func (api *Client) KickUserFromChannel(channel, user string) error {
 		"channel": {channel},
 		"user":    {user},
 	}
-	_, err := channelRequest("channels.kick", values, api.debug)
+	_, err := api.channelRequest("channels.kick", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func (api *Client) GetChannels(excludeArchived bool) ([]Channel, error) {
 	if excludeArchived {
 		values.Add("exclude_archived", "1")
 	}
-	response, err := channelRequest("channels.list", values, api.debug)
+	response, err := api.channelRequest("channels.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (api *Client) SetChannelReadMark(channel, ts string) error {
 		"channel": {channel},
 		"ts":      {ts},
 	}
-	_, err := channelRequest("channels.mark", values, api.debug)
+	_, err := api.channelRequest("channels.mark", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (api *Client) RenameChannel(channel, name string) (*Channel, error) {
 	}
 	// XXX: the created entry in this call returns a string instead of a number
 	// so I may have to do some workaround to solve it.
-	response, err := channelRequest("channels.rename", values, api.debug)
+	response, err := api.channelRequest("channels.rename", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (api *Client) SetChannelPurpose(channel, purpose string) (string, error) {
 		"channel": {channel},
 		"purpose": {purpose},
 	}
-	response, err := channelRequest("channels.setPurpose", values, api.debug)
+	response, err := api.channelRequest("channels.setPurpose", values, api.debug)
 	if err != nil {
 		return "", err
 	}
@@ -246,7 +246,7 @@ func (api *Client) SetChannelTopic(channel, topic string) (string, error) {
 		"channel": {channel},
 		"topic":   {topic},
 	}
-	response, err := channelRequest("channels.setTopic", values, api.debug)
+	response, err := api.channelRequest("channels.setTopic", values, api.debug)
 	if err != nil {
 		return "", err
 	}

--- a/chat.go
+++ b/chat.go
@@ -60,9 +60,9 @@ func NewPostMessageParameters() PostMessageParameters {
 	}
 }
 
-func chatRequest(path string, values url.Values, debug bool) (*chatResponseFull, error) {
+func (api *Client) chatRequest(path string, values url.Values, debug bool) (*chatResponseFull, error) {
 	response := &chatResponseFull{}
-	err := post(path, values, response, debug)
+	err := api.post(path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (api *Client) DeleteMessage(channel, messageTimestamp string) (string, stri
 		"channel": {channel},
 		"ts":      {messageTimestamp},
 	}
-	response, err := chatRequest("chat.delete", values, api.debug)
+	response, err := api.chatRequest("chat.delete", values, api.debug)
 	if err != nil {
 		return "", "", err
 	}
@@ -138,7 +138,7 @@ func (api *Client) PostMessage(channel, text string, params PostMessageParameter
 		values.Set("mrkdwn", "false")
 	}
 
-	response, err := chatRequest("chat.postMessage", values, api.debug)
+	response, err := api.chatRequest("chat.postMessage", values, api.debug)
 	if err != nil {
 		return "", "", err
 	}
@@ -153,7 +153,7 @@ func (api *Client) UpdateMessage(channel, timestamp, text string) (string, strin
 		"text":    {escapeMessage(text)},
 		"ts":      {timestamp},
 	}
-	response, err := chatRequest("chat.update", values, api.debug)
+	response, err := api.chatRequest("chat.update", values, api.debug)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/emoji.go
+++ b/emoji.go
@@ -16,7 +16,7 @@ func (api *Client) GetEmoji() (map[string]string, error) {
 		"token": {api.config.token},
 	}
 	response := &emojiResponseFull{}
-	err := post("emoji.list", values, response, api.debug)
+	err := api.post("emoji.list", values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/files.go
+++ b/files.go
@@ -107,9 +107,9 @@ func NewGetFilesParameters() GetFilesParameters {
 	}
 }
 
-func fileRequest(path string, values url.Values, debug bool) (*fileResponseFull, error) {
+func (api *Client) fileRequest(path string, values url.Values, debug bool) (*fileResponseFull, error) {
 	response := &fileResponseFull{}
-	err := post(path, values, response, debug)
+	err := api.post(path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (api *Client) GetFileInfo(fileID string, count, page int) (*File, []Comment
 		"count": {strconv.Itoa(count)},
 		"page":  {strconv.Itoa(page)},
 	}
-	response, err := fileRequest("files.info", values, api.debug)
+	response, err := api.fileRequest("files.info", values, api.debug)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -158,7 +158,7 @@ func (api *Client) GetFiles(params GetFilesParameters) ([]File, *Paging, error) 
 	if params.Page != DEFAULT_FILES_PAGE {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
-	response, err := fileRequest("files.list", values, api.debug)
+	response, err := api.fileRequest("files.list", values, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -194,9 +194,9 @@ func (api *Client) UploadFile(params FileUploadParameters) (file *File, err erro
 	}
 	if params.Content != "" {
 		values.Add("content", params.Content)
-		err = post("files.upload", values, response, api.debug)
+		err = api.post("files.upload", values, response, api.debug)
 	} else if params.File != "" {
-		err = postWithMultipartResponse("files.upload", params.File, values, response, api.debug)
+		err = api.postWithMultipartResponse("files.upload", params.File, values, response, api.debug)
 	}
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func (api *Client) DeleteFile(fileID string) error {
 		"token": {api.config.token},
 		"file":  {fileID},
 	}
-	_, err := fileRequest("files.delete", values, api.debug)
+	_, err := api.fileRequest("files.delete", values, api.debug)
 	if err != nil {
 		return err
 	}

--- a/groups.go
+++ b/groups.go
@@ -27,9 +27,9 @@ type groupResponseFull struct {
 	SlackResponse
 }
 
-func groupRequest(path string, values url.Values, debug bool) (*groupResponseFull, error) {
+func (api *Client) groupRequest(path string, values url.Values, debug bool) (*groupResponseFull, error) {
 	response := &groupResponseFull{}
-	err := post(path, values, response, debug)
+	err := api.post(path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (api *Client) ArchiveGroup(group string) error {
 		"token":   {api.config.token},
 		"channel": {group},
 	}
-	_, err := groupRequest("groups.archive", values, api.debug)
+	_, err := api.groupRequest("groups.archive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (api *Client) UnarchiveGroup(group string) error {
 		"token":   {api.config.token},
 		"channel": {group},
 	}
-	_, err := groupRequest("groups.unarchive", values, api.debug)
+	_, err := api.groupRequest("groups.unarchive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (api *Client) CreateGroup(group string) (*Group, error) {
 		"token": {api.config.token},
 		"name":  {group},
 	}
-	response, err := groupRequest("groups.create", values, api.debug)
+	response, err := api.groupRequest("groups.create", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (api *Client) CreateChildGroup(group string) (*Group, error) {
 		"token":   {api.config.token},
 		"channel": {group},
 	}
-	response, err := groupRequest("groups.createChild", values, api.debug)
+	response, err := api.groupRequest("groups.createChild", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (api *Client) CloseGroup(group string) (bool, bool, error) {
 		"token":   {api.config.token},
 		"channel": {group},
 	}
-	response, err := imRequest("groups.close", values, api.debug)
+	response, err := api.imRequest("groups.close", values, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -131,7 +131,7 @@ func (api *Client) GetGroupHistory(group string, params HistoryParameters) (*His
 			values.Add("inclusive", "0")
 		}
 	}
-	response, err := groupRequest("groups.history", values, api.debug)
+	response, err := api.groupRequest("groups.history", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (api *Client) InviteUserToGroup(group, user string) (*Group, bool, error) {
 		"channel": {group},
 		"user":    {user},
 	}
-	response, err := groupRequest("groups.invite", values, api.debug)
+	response, err := api.groupRequest("groups.invite", values, api.debug)
 	if err != nil {
 		return nil, false, err
 	}
@@ -158,7 +158,7 @@ func (api *Client) LeaveGroup(group string) error {
 		"token":   {api.config.token},
 		"channel": {group},
 	}
-	_, err := groupRequest("groups.leave", values, api.debug)
+	_, err := api.groupRequest("groups.leave", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (api *Client) KickUserFromGroup(group, user string) error {
 		"channel": {group},
 		"user":    {user},
 	}
-	_, err := groupRequest("groups.kick", values, api.debug)
+	_, err := api.groupRequest("groups.kick", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func (api *Client) GetGroups(excludeArchived bool) ([]Group, error) {
 	if excludeArchived {
 		values.Add("exclude_archived", "1")
 	}
-	response, err := groupRequest("groups.list", values, api.debug)
+	response, err := api.groupRequest("groups.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (api *Client) GetGroupInfo(group string) (*Group, error) {
 		"token":   {api.config.token},
 		"channel": {group},
 	}
-	response, err := groupRequest("groups.info", values, api.debug)
+	response, err := api.groupRequest("groups.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (api *Client) SetGroupReadMark(group, ts string) error {
 		"channel": {group},
 		"ts":      {ts},
 	}
-	_, err := groupRequest("groups.mark", values, api.debug)
+	_, err := api.groupRequest("groups.mark", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (api *Client) OpenGroup(group string) (bool, bool, error) {
 		"token": {api.config.token},
 		"user":  {group},
 	}
-	response, err := groupRequest("groups.open", values, api.debug)
+	response, err := api.groupRequest("groups.open", values, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -249,7 +249,7 @@ func (api *Client) RenameGroup(group, name string) (*Channel, error) {
 	}
 	// XXX: the created entry in this call returns a string instead of a number
 	// so I may have to do some workaround to solve it.
-	response, err := groupRequest("groups.rename", values, api.debug)
+	response, err := api.groupRequest("groups.rename", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (api *Client) SetGroupPurpose(group, purpose string) (string, error) {
 		"channel": {group},
 		"purpose": {purpose},
 	}
-	response, err := groupRequest("groups.setPurpose", values, api.debug)
+	response, err := api.groupRequest("groups.setPurpose", values, api.debug)
 	if err != nil {
 		return "", err
 	}
@@ -278,7 +278,7 @@ func (api *Client) SetGroupTopic(group, topic string) (string, error) {
 		"channel": {group},
 		"topic":   {topic},
 	}
-	response, err := groupRequest("groups.setTopic", values, api.debug)
+	response, err := api.groupRequest("groups.setTopic", values, api.debug)
 	if err != nil {
 		return "", err
 	}

--- a/im.go
+++ b/im.go
@@ -28,9 +28,9 @@ type IM struct {
 	IsUserDeleted bool   `json:"is_user_deleted"`
 }
 
-func imRequest(path string, values url.Values, debug bool) (*imResponseFull, error) {
+func (api *Client) imRequest(path string, values url.Values, debug bool) (*imResponseFull, error) {
 	response := &imResponseFull{}
-	err := post(path, values, response, debug)
+	err := api.post(path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (api *Client) CloseIMChannel(channel string) (bool, bool, error) {
 		"token":   {api.config.token},
 		"channel": {channel},
 	}
-	response, err := imRequest("im.close", values, api.debug)
+	response, err := api.imRequest("im.close", values, api.debug)
 	if err != nil {
 		return false, false, err
 	}
@@ -60,7 +60,7 @@ func (api *Client) OpenIMChannel(user string) (bool, bool, string, error) {
 		"token": {api.config.token},
 		"user":  {user},
 	}
-	response, err := imRequest("im.open", values, api.debug)
+	response, err := api.imRequest("im.open", values, api.debug)
 	if err != nil {
 		return false, false, "", err
 	}
@@ -74,7 +74,7 @@ func (api *Client) MarkIMChannel(channel, ts string) (err error) {
 		"channel": {channel},
 		"ts":      {ts},
 	}
-	_, err = imRequest("im.mark", values, api.debug)
+	_, err = api.imRequest("im.mark", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (api *Client) GetIMHistory(channel string, params HistoryParameters) (*Hist
 			values.Add("inclusive", "0")
 		}
 	}
-	response, err := imRequest("im.history", values, api.debug)
+	response, err := api.imRequest("im.history", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (api *Client) GetIMChannels() ([]IM, error) {
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	response, err := imRequest("im.list", values, api.debug)
+	response, err := api.imRequest("im.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/misc.go
+++ b/misc.go
@@ -88,10 +88,9 @@ func parseResponseBody(body io.ReadCloser, intf *interface{}, debug bool) error 
 	return nil
 }
 
-func postWithMultipartResponse(path string, filepath string, values url.Values, intf interface{}, debug bool) error {
+func (api *Client) postWithMultipartResponse(path string, filepath string, values url.Values, intf interface{}, debug bool) error {
 	req, err := fileUploadReq(SLACK_API+path, filepath, values)
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := api.fromHTTPClient().Do(req)
 	if err != nil {
 		return err
 	}
@@ -99,8 +98,8 @@ func postWithMultipartResponse(path string, filepath string, values url.Values, 
 	return parseResponseBody(resp.Body, &intf, debug)
 }
 
-func postForm(endpoint string, values url.Values, intf interface{}, debug bool) error {
-	resp, err := http.PostForm(endpoint, values)
+func (api *Client) postForm(endpoint string, values url.Values, intf interface{}, debug bool) error {
+	resp, err := api.fromHTTPClient().PostForm(endpoint, values)
 	if err != nil {
 		return err
 	}
@@ -109,11 +108,11 @@ func postForm(endpoint string, values url.Values, intf interface{}, debug bool) 
 	return parseResponseBody(resp.Body, &intf, debug)
 }
 
-func post(path string, values url.Values, intf interface{}, debug bool) error {
-	return postForm(SLACK_API+path, values, intf, debug)
+func (api *Client) post(path string, values url.Values, intf interface{}, debug bool) error {
+	return api.postForm(SLACK_API+path, values, intf, debug)
 }
 
-func parseAdminResponse(method string, teamName string, values url.Values, intf interface{}, debug bool) error {
+func (api *Client) parseAdminResponse(method string, teamName string, values url.Values, intf interface{}, debug bool) error {
 	endpoint := fmt.Sprintf(SLACK_WEB_API_FORMAT, teamName, method, time.Now().Unix())
-	return postForm(endpoint, values, intf, debug)
+	return api.postForm(endpoint, values, intf, debug)
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -40,7 +40,7 @@ func TestParseResponse(t *testing.T) {
 		"token": {validToken},
 	}
 	responsePartial := &SlackResponse{}
-	err := post("parseResponse", values, responsePartial, false)
+	err := New(validToken).post("parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -52,7 +52,7 @@ func TestParseResponseNoToken(t *testing.T) {
 	SLACK_API = "http://" + serverAddr + "/"
 	values := url.Values{}
 	responsePartial := &SlackResponse{}
-	err := post("parseResponse", values, responsePartial, false)
+	err := New(validToken).post("parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return
@@ -72,7 +72,7 @@ func TestParseResponseInvalidToken(t *testing.T) {
 		"token": {"whatever"},
 	}
 	responsePartial := &SlackResponse{}
-	err := post("parseResponse", values, responsePartial, false)
+	err := New(validToken).post("parseResponse", values, responsePartial, false)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 		return

--- a/oauth.go
+++ b/oauth.go
@@ -12,7 +12,7 @@ type oAuthResponseFull struct {
 }
 
 // GetOAuthToken retrieves an AccessToken
-func GetOAuthToken(clientID, clientSecret, code, redirectURI string, debug bool) (accessToken string, scope string, err error) {
+func (api *Client) GetOAuthToken(clientID, clientSecret, code, redirectURI string, debug bool) (accessToken string, scope string, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
 		"client_secret": {clientSecret},
@@ -20,7 +20,7 @@ func GetOAuthToken(clientID, clientSecret, code, redirectURI string, debug bool)
 		"redirect_uri":  {redirectURI},
 	}
 	response := &oAuthResponseFull{}
-	err = post("oauth.access", values, response, debug)
+	err = api.post("oauth.access", values, response, debug)
 	if err != nil {
 		return "", "", err
 	}

--- a/pins.go
+++ b/pins.go
@@ -27,7 +27,7 @@ func (api *Client) AddPin(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("pins.add", values, response, api.debug); err != nil {
+	if err := api.post("pins.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -52,7 +52,7 @@ func (api *Client) RemovePin(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("pins.remove", values, response, api.debug); err != nil {
+	if err := api.post("pins.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -68,7 +68,7 @@ func (api *Client) ListPins(channel string) ([]Item, *Paging, error) {
 		"token":   {api.config.token},
 	}
 	response := &listPinsResponseFull{}
-	err := post("pins.list", values, response, api.debug)
+	err := api.post("pins.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/reactions.go
+++ b/reactions.go
@@ -149,7 +149,7 @@ func (api *Client) AddReaction(name string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("reactions.add", values, response, api.debug); err != nil {
+	if err := api.post("reactions.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -179,7 +179,7 @@ func (api *Client) RemoveReaction(name string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("reactions.remove", values, response, api.debug); err != nil {
+	if err := api.post("reactions.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -209,7 +209,7 @@ func (api *Client) GetReactions(item ItemRef, params GetReactionsParameters) ([]
 		values.Set("full", strconv.FormatBool(params.Full))
 	}
 	response := &getReactionsResponseFull{}
-	if err := post("reactions.get", values, response, api.debug); err != nil {
+	if err := api.post("reactions.get", values, response, api.debug); err != nil {
 		return nil, err
 	}
 	if !response.Ok {
@@ -236,7 +236,7 @@ func (api *Client) ListReactions(params ListReactionsParameters) ([]ReactedItem,
 		values.Add("full", strconv.FormatBool(params.Full))
 	}
 	response := &listReactionsResponseFull{}
-	err := post("reactions.list", values, response, api.debug)
+	err := api.post("reactions.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/rtm.go
+++ b/rtm.go
@@ -12,7 +12,7 @@ import (
 // on it.
 func (api *Client) StartRTM() (info *Info, websocketURL string, err error) {
 	response := &infoResponseFull{}
-	err = post("rtm.start", url.Values{"token": {api.config.token}}, response, api.debug)
+	err = api.post("rtm.start", url.Values{"token": {api.config.token}}, response, api.debug)
 	if err != nil {
 		return nil, "", fmt.Errorf("post: %s", err)
 	}

--- a/search.go
+++ b/search.go
@@ -101,7 +101,7 @@ func (api *Client) _search(path, query string, params SearchParameters, files, m
 		values.Add("page", strconv.Itoa(params.Page))
 	}
 	response = &searchResponseFull{}
-	err := post(path, values, response, api.debug)
+	err := api.post(path, values, response, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/slack.go
+++ b/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"errors"
 	"log"
+	"net/http"
 	"net/url"
 )
 
@@ -31,6 +32,8 @@ type authTestResponseFull struct {
 }
 
 type Client struct {
+	httpClient *http.Client
+
 	config struct {
 		token string
 	}
@@ -44,10 +47,22 @@ func New(token string) *Client {
 	return s
 }
 
+func (api *Client) WithHTTPClient(httpClient *http.Client) {
+	api.httpClient = httpClient
+}
+
+func (api *Client) fromHTTPClient() *http.Client {
+	if api.httpClient != nil {
+		return api.httpClient
+	}
+
+	return http.DefaultClient
+}
+
 // AuthTest tests if the user is able to do authenticated requests or not
 func (api *Client) AuthTest() (response *AuthTestResponse, error error) {
 	responseFull := &authTestResponseFull{}
-	err := post("auth.test", url.Values{"token": {api.config.token}}, responseFull, api.debug)
+	err := api.post("auth.test", url.Values{"token": {api.config.token}}, responseFull, api.debug)
 	if err != nil {
 		return nil, err
 	}

--- a/stars.go
+++ b/stars.go
@@ -51,7 +51,7 @@ func (api *Client) AddStar(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("stars.add", values, response, api.debug); err != nil {
+	if err := api.post("stars.add", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -76,7 +76,7 @@ func (api *Client) RemoveStar(channel string, item ItemRef) error {
 		values.Set("file_comment", string(item.Comment))
 	}
 	response := &SlackResponse{}
-	if err := post("stars.remove", values, response, api.debug); err != nil {
+	if err := api.post("stars.remove", values, response, api.debug); err != nil {
 		return err
 	}
 	if !response.Ok {
@@ -100,7 +100,7 @@ func (api *Client) ListStars(params StarsParameters) ([]Item, *Paging, error) {
 		values.Add("page", strconv.Itoa(params.Page))
 	}
 	response := &listResponseFull{}
-	err := post("stars.list", values, response, api.debug)
+	err := api.post("stars.list", values, response, api.debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/users.go
+++ b/users.go
@@ -62,9 +62,9 @@ type userResponseFull struct {
 	SlackResponse
 }
 
-func userRequest(path string, values url.Values, debug bool) (*userResponseFull, error) {
+func (api *Client) userRequest(path string, values url.Values, debug bool) (*userResponseFull, error) {
 	response := &userResponseFull{}
-	err := post(path, values, response, debug)
+	err := api.post(path, values, response, debug)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (api *Client) GetUserPresence(user string) (*UserPresence, error) {
 		"token": {api.config.token},
 		"user":  {user},
 	}
-	response, err := userRequest("users.getPresence", values, api.debug)
+	response, err := api.userRequest("users.getPresence", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (api *Client) GetUserInfo(user string) (*User, error) {
 		"token": {api.config.token},
 		"user":  {user},
 	}
-	response, err := userRequest("users.info", values, api.debug)
+	response, err := api.userRequest("users.info", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (api *Client) GetUsers() ([]User, error) {
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	response, err := userRequest("users.list", values, api.debug)
+	response, err := api.userRequest("users.list", values, api.debug)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (api *Client) SetUserAsActive() error {
 	values := url.Values{
 		"token": {api.config.token},
 	}
-	_, err := userRequest("users.setActive", values, api.debug)
+	_, err := api.userRequest("users.setActive", values, api.debug)
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (api *Client) SetUserPresence(presence string) error {
 		"token":    {api.config.token},
 		"presence": {presence},
 	}
-	_, err := userRequest("users.setPresence", values, api.debug)
+	_, err := api.userRequest("users.setPresence", values, api.debug)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
AppEngine Example 

```go
import (
    "fmt"

    "github.com/nlopes/slack"

    "golang.org/x/net/context"
    "google.golang.org/appengine"
    "google.golang.org/appengine/urlfetch"
)

func handler(w http.ResponseWriter, r *http.Request) {
    ctx := appengine.NewContext(r)

    api := slack.New("YOUR_TOKEN_HERE")
    api.WithHTTPClient(urlfetch.NewClient(ctx))
    // If you set debugging, it will log all requests to the console
    // Useful when encountering issues
    // api.SetDebug(true)
    groups, err := api.GetGroups(false)
    if err != nil {
        fmt.Printf("%s\n", err)
        return
    }
    for _, group := range groups {
        fmt.Printf("ID: %s, Name: %s\n", group.ID, group.Name)
    }

    // ... 
}
```